### PR TITLE
OCP-1821: Set default mongo version to 3.4.7

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,7 +8,7 @@ mongodb_conf_file: /etc/mongod.conf
 
 ###########
 ## Package
-mongodb_version:          3.4.3
+mongodb_version:          3.4.7
 mongodb_major_version:    "{{ mongodb_version.split('.')|first }}"
 mongodb_minor_version:    "{{ mongodb_version.split('.')[1] }}"
 mongodb_repo_version:     "{{ mongodb_major_version }}.{{ mongodb_minor_version }}"


### PR DESCRIPTION
This is our default now, so as I change mongodb_version for the upgrade,
I want to ensure all non-upgraded instances stay on 3.4.7