### PR TITLE
Fix issue where mongo will not be listening if it was restarted

### DIFF
--- a/tasks/replica_set.yml
+++ b/tasks/replica_set.yml
@@ -20,6 +20,11 @@
 
 - debug: msg="{{ ansible_local.mongodb }}"
 
+- name: Wait for mongo to come up in case it was restarted above
+  wait_for:
+    host: {{ ansible_default_ipv4.address }}
+    port: {{ mongodb_net.port }}
+
 - name: Check if replica set has been initialized
   shell: >
       mongo --host {{ mongodb_net.bindIp }} --port {{ mongodb_net.port }} \


### PR DESCRIPTION
meta: flush_handlers is called a few tasks before a call to port 27017.
If mongo has just been upgraded, this port may not be listening in time,
so we need to wait for it. This caused an error when upgrading mongo on
25th Jan 2018 - the infra deploy job had to be restarted